### PR TITLE
Make eslint a local pre-commit hook

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,12 +6,15 @@ module.exports = {
     plugins: ['flowtype', 'prettier'],
 
     rules: {
-        'prettier/prettier': ['error', {
-            printWidth: 120,
-            singleQuote: true,
-            tabWidth: 4,
-            trailingComma: 'all',
-        }],
+        'prettier/prettier': [
+            'error',
+            {
+                printWidth: 120,
+                singleQuote: true,
+                tabWidth: 4,
+                trailingComma: 'all',
+            },
+        ],
 
         // https://github.com/airbnb/javascript/pull/985#issuecomment-239145468
         'react/jsx-filename-extension': 'off',

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,18 +6,11 @@
     -   id: check-added-large-files
     -   id: check-json
     -   id: check-yaml
--   repo: https://github.com/pre-commit/mirrors-eslint
-    sha: v4.6.0
+-   repo: local
     hooks:
     -   id: eslint
-        additional_dependencies:
-        -   eslint@4.15.0
-        -   eslint-config-airbnb@^15.1.0
-        -   eslint-config-prettier@^2.3.0
-        -   eslint-plugin-flowtype@^2.39.1
-        -   eslint-plugin-import@^2.8.0
-        -   eslint-plugin-jsx-a11y@^5.1.1
-        -   eslint-plugin-prettier@^2.5.0
-        -   eslint-plugin-react@^7.3.0
-        -   babel-eslint@^8.1.2
-        -   prettier@1.5.3
+        name: eslint
+        entry: ./node_modules/.bin/eslint
+        language: system
+        files: \.js$
+        args: ['--fix', '--ignore-pattern=!.eslintrc.js']

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
+--add.no-lockfile true
 --install.no-lockfile true

--- a/package.json
+++ b/package.json
@@ -23,10 +23,19 @@
     "enzyme": "^3.1.1",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.0",
+    "eslint": "^4.9.0",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-flowtype": "^2.43.0",
+    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-prettier": "^2.6.0",
+    "eslint-plugin-react": "^7.4.0",
     "flow-bin": "^0.61.0",
     "flow-copy-source": "^1.2.1",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^22.0.4"
+    "jest": "^22.0.4",
+    "prettier": "^1.10.2"
   },
   "files": [
     "lib",

--- a/src/components/DomTags/DomTags.js
+++ b/src/components/DomTags/DomTags.js
@@ -94,10 +94,11 @@ type Props = {
     tagRef?: ?React.Ref<*>,
 };
 
-export const DomTags = ({ tag: Tag, children, className, tagRef, ...otherProps }: Props) =>
+export const DomTags = ({ tag: Tag, children, className, tagRef, ...otherProps }: Props) => (
     <Tag className={classNames(styles[`domtags--${Tag}`], className)} ref={tagRef} {...otherProps}>
         {children}
-    </Tag>;
+    </Tag>
+);
 
 DomTags.defaultProps = {
     children: null,
@@ -109,15 +110,17 @@ type NoChildTagProps = {
     className?: string,
 };
 
-export const Embed = ({ className, ...otherProps }: NoChildTagProps) =>
-    <DomTags tag="embed" className={className} {...otherProps} />;
+export const Embed = ({ className, ...otherProps }: NoChildTagProps) => (
+    <DomTags tag="embed" className={className} {...otherProps} />
+);
 
 Embed.defaultProps = {
     className: '',
 };
 
-export const Img = ({ className, ...otherProps }: NoChildTagProps) =>
-    <DomTags tag="img" className={className} {...otherProps} />;
+export const Img = ({ className, ...otherProps }: NoChildTagProps) => (
+    <DomTags tag="img" className={className} {...otherProps} />
+);
 
 Img.defaultProps = {
     className: '',
@@ -128,770 +131,847 @@ type TagProps = {
     className?: string,
 };
 
-export const A = ({ children, className, ...otherProps }: TagProps) =>
+export const A = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="a" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 A.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Abbr = ({ children, className, ...otherProps }: TagProps) =>
+export const Abbr = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="abbr" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Abbr.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Acronym = ({ children, className, ...otherProps }: TagProps) =>
+export const Acronym = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="acronym" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Acronym.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Address = ({ children, className, ...otherProps }: TagProps) =>
+export const Address = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="address" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Address.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Applet = ({ children, className, ...otherProps }: TagProps) =>
+export const Applet = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="applet" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Applet.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Article = ({ children, className, ...otherProps }: TagProps) =>
+export const Article = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="article" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Article.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Aside = ({ children, className, ...otherProps }: TagProps) =>
+export const Aside = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="aside" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Aside.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Audio = ({ children, className, ...otherProps }: TagProps) =>
+export const Audio = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="audio" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Audio.defaultProps = {
     children: null,
     className: '',
 };
 
-export const B = ({ children, className, ...otherProps }: TagProps) =>
+export const B = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="b" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 B.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Big = ({ children, className, ...otherProps }: TagProps) =>
+export const Big = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="big" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Big.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Blockquote = ({ children, className, ...otherProps }: TagProps) =>
+export const Blockquote = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="blockquote" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Blockquote.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Canvas = ({ children, className, ...otherProps }: TagProps) =>
+export const Canvas = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="canvas" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Canvas.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Caption = ({ children, className, ...otherProps }: TagProps) =>
+export const Caption = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="caption" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Caption.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Center = ({ children, className, ...otherProps }: TagProps) =>
+export const Center = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="center" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Center.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Cite = ({ children, className, ...otherProps }: TagProps) =>
+export const Cite = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="cite" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Cite.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Code = ({ children, className, ...otherProps }: TagProps) =>
+export const Code = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="code" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Code.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Dd = ({ children, className, ...otherProps }: TagProps) =>
+export const Dd = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="dd" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Dd.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Del = ({ children, className, ...otherProps }: TagProps) =>
+export const Del = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="del" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Del.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Details = ({ children, className, ...otherProps }: TagProps) =>
+export const Details = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="details" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Details.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Dfn = ({ children, className, ...otherProps }: TagProps) =>
+export const Dfn = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="dfn" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Dfn.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Div = ({ children, className, ...otherProps }: TagProps) =>
+export const Div = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="div" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Div.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Dl = ({ children, className, ...otherProps }: TagProps) =>
+export const Dl = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="dl" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Dl.defaultProps = {
     children: null,
     className: '',
 };
 
-export const DomObject = ({ children, className, ...otherProps }: TagProps) =>
+export const DomObject = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="object" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 DomObject.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Dt = ({ children, className, ...otherProps }: TagProps) =>
+export const Dt = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="dt" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Dt.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Em = ({ children, className, ...otherProps }: TagProps) =>
+export const Em = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="em" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Em.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Fieldset = ({ children, className, ...otherProps }: TagProps) =>
+export const Fieldset = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="fieldset" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Fieldset.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Figcaption = ({ children, className, ...otherProps }: TagProps) =>
+export const Figcaption = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="figcaption" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Figcaption.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Figure = ({ children, className, ...otherProps }: TagProps) =>
+export const Figure = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="figure" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Figure.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Footer = ({ children, className, ...otherProps }: TagProps) =>
+export const Footer = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="footer" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Footer.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Form = ({ children, className, ...otherProps }: TagProps) =>
+export const Form = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="form" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Form.defaultProps = {
     children: null,
     className: '',
 };
 
-export const H1 = ({ children, className, ...otherProps }: TagProps) =>
+export const H1 = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="h1" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 H1.defaultProps = {
     children: null,
     className: '',
 };
 
-export const H2 = ({ children, className, ...otherProps }: TagProps) =>
+export const H2 = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="h2" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 H2.defaultProps = {
     children: null,
     className: '',
 };
 
-export const H3 = ({ children, className, ...otherProps }: TagProps) =>
+export const H3 = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="h3" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 H3.defaultProps = {
     children: null,
     className: '',
 };
 
-export const H4 = ({ children, className, ...otherProps }: TagProps) =>
+export const H4 = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="h4" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 H4.defaultProps = {
     children: null,
     className: '',
 };
 
-export const H5 = ({ children, className, ...otherProps }: TagProps) =>
+export const H5 = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="h5" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 H5.defaultProps = {
     children: null,
     className: '',
 };
 
-export const H6 = ({ children, className, ...otherProps }: TagProps) =>
+export const H6 = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="h6" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 H6.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Header = ({ children, className, ...otherProps }: TagProps) =>
+export const Header = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="header" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Header.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Hgroup = ({ children, className, ...otherProps }: TagProps) =>
+export const Hgroup = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="hgroup" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Hgroup.defaultProps = {
     children: null,
     className: '',
 };
 
-export const I = ({ children, className, ...otherProps }: TagProps) =>
+export const I = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="i" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 I.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Iframe = ({ children, className, ...otherProps }: TagProps) =>
+export const Iframe = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="iframe" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Iframe.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Ins = ({ children, className, ...otherProps }: TagProps) =>
+export const Ins = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="ins" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Ins.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Kbd = ({ children, className, ...otherProps }: TagProps) =>
+export const Kbd = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="kbd" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Kbd.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Label = ({ children, className, ...otherProps }: TagProps) =>
+export const Label = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="label" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Label.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Legend = ({ children, className, ...otherProps }: TagProps) =>
+export const Legend = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="legend" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Legend.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Li = ({ children, className, ...otherProps }: TagProps) =>
+export const Li = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="li" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Li.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Mark = ({ children, className, ...otherProps }: TagProps) =>
+export const Mark = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="mark" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Mark.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Menu = ({ children, className, ...otherProps }: TagProps) =>
+export const Menu = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="menu" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Menu.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Nav = ({ children, className, ...otherProps }: TagProps) =>
+export const Nav = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="nav" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Nav.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Ol = ({ children, className, ...otherProps }: TagProps) =>
+export const Ol = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="ol" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Ol.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Output = ({ children, className, ...otherProps }: TagProps) =>
+export const Output = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="output" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Output.defaultProps = {
     children: null,
     className: '',
 };
 
-export const P = ({ children, className, ...otherProps }: TagProps) =>
+export const P = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="p" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 P.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Pre = ({ children, className, ...otherProps }: TagProps) =>
+export const Pre = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="pre" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Pre.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Q = ({ children, className, ...otherProps }: TagProps) =>
+export const Q = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="q" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Q.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Ruby = ({ children, className, ...otherProps }: TagProps) =>
+export const Ruby = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="ruby" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Ruby.defaultProps = {
     children: null,
     className: '',
 };
 
-export const S = ({ children, className, ...otherProps }: TagProps) =>
+export const S = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="s" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 S.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Samp = ({ children, className, ...otherProps }: TagProps) =>
+export const Samp = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="samp" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Samp.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Section = ({ children, className, ...otherProps }: TagProps) =>
+export const Section = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="section" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Section.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Small = ({ children, className, ...otherProps }: TagProps) =>
+export const Small = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="small" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Small.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Span = ({ children, className, ...otherProps }: TagProps) =>
+export const Span = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="span" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Span.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Strike = ({ children, className, ...otherProps }: TagProps) =>
+export const Strike = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="strike" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Strike.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Strong = ({ children, className, ...otherProps }: TagProps) =>
+export const Strong = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="strong" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Strong.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Sub = ({ children, className, ...otherProps }: TagProps) =>
+export const Sub = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="sub" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Sub.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Summary = ({ children, className, ...otherProps }: TagProps) =>
+export const Summary = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="summary" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Summary.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Sup = ({ children, className, ...otherProps }: TagProps) =>
+export const Sup = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="sup" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Sup.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Table = ({ children, className, ...otherProps }: TagProps) =>
+export const Table = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="table" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Table.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Tbody = ({ children, className, ...otherProps }: TagProps) =>
+export const Tbody = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="tbody" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Tbody.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Td = ({ children, className, ...otherProps }: TagProps) =>
+export const Td = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="td" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Td.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Tfoot = ({ children, className, ...otherProps }: TagProps) =>
+export const Tfoot = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="tfoot" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Tfoot.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Th = ({ children, className, ...otherProps }: TagProps) =>
+export const Th = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="th" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Th.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Thead = ({ children, className, ...otherProps }: TagProps) =>
+export const Thead = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="thead" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Thead.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Time = ({ children, className, ...otherProps }: TagProps) =>
+export const Time = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="time" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Time.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Tr = ({ children, className, ...otherProps }: TagProps) =>
+export const Tr = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="tr" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Tr.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Tt = ({ children, className, ...otherProps }: TagProps) =>
+export const Tt = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="tt" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Tt.defaultProps = {
     children: null,
     className: '',
 };
 
-export const U = ({ children, className, ...otherProps }: TagProps) =>
+export const U = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="u" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 U.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Ul = ({ children, className, ...otherProps }: TagProps) =>
+export const Ul = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="ul" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Ul.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Var = ({ children, className, ...otherProps }: TagProps) =>
+export const Var = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="var" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Var.defaultProps = {
     children: null,
     className: '',
 };
 
-export const Video = ({ children, className, ...otherProps }: TagProps) =>
+export const Video = ({ children, className, ...otherProps }: TagProps) => (
     <DomTags tag="video" className={className} {...otherProps}>
         {children}
-    </DomTags>;
+    </DomTags>
+);
 
 Video.defaultProps = {
     children: null,


### PR DESCRIPTION
This makes it so that _both_ pre-commit and IDE integrations can use eslint. The diff in `src` is likely due to the prettier upgrade.