### PR TITLE
Update react dependency strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "typecheck": "flow check"
   },
   "dependencies": {
-    "classnames": "^2.2.5",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "classnames": "^2.2.5"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -35,7 +33,12 @@
     "flow-copy-source": "^1.2.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^22.0.4",
-    "prettier": "^1.10.2"
+    "prettier": "^1.10.2",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
+  },
+  "peerDependencies": {
+    "react": "15.x || 16.x"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This is consistent with our new internal strategy

(tl;dr react-dom is not a direct dependency of this package, and react should be a peerDep as this plugs into an existing react application)

More info: https://yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies