### PR TITLE
Generate the scss automatically!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,13 @@ venv: Makefile requirements-dev.txt
 node_modules: package.json
 	yarn
 
+.PHONY: gen
+gen: node_modules
+	curl https://meyerweb.com/eric/tools/css/reset/reset.css | \
+		python gencss.py | \
+		node_modules/.bin/prettier --stdin --stdin-filepath=x.scss > \
+		src/components/LemonReset/LemonReset.scss
+
 .PHONY: clean
 clean:
 	rm -rf coverage

--- a/gencss.py
+++ b/gencss.py
@@ -1,0 +1,25 @@
+"""Pass a reset css as stdin to be rewritten"""
+import re
+import sys
+
+
+def _replace(s, to_remove):
+    assert to_remove in s, (to_remove, s)
+    return s.replace(to_remove, '')
+
+
+def main():
+    contents = sys.stdin.read()
+    # don't style body / html
+    contents = _replace(contents, 'html, body, ')
+    contents = _replace(contents, 'body {\n\tline-height: 1;\n}\n')
+    # meyer-reset has trailing whitespace :'(
+    contents = contents.replace(' \n', '\n')
+    # replace with our classname
+    contents = re.sub('([a-z0-9:]+(,| {))', r'.lemon--\1', contents)
+
+    sys.stdout.write(contents)
+
+
+if __name__ == '__main__':
+    exit(main())


### PR DESCRIPTION
Mostly as a followup to https://github.com/Yelp/lemon-reset/pull/18

This (perhaps not surprisingly) doesn't change any of the scss.  Additionally, I think the js can be generated as well but wanted to get this out there before investing time in that.

I initially started trying to do this with a `sed` pipeline but didn't really want to have to reach into `perl` to get multiline replaces :)

This was my `sed` pipeline in case someone has some more clever to make that work:
```bash
cat reset.css | sed -r 's/html, body, //;s/([a-z0-9:]+(,| \{))/.lemon--\1/g;s/ $//g' | ./node_modules/.bin/prettier --stdin --stdin-filepath=x.scss
```