### PR TITLE
Remove scss dependency from lemon-reset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
     -   id: eslint
         name: eslint
-        entry: ./node_modules/.bin/eslint
+        entry: yarn eslint
         language: system
         files: \.js$
         args: ['--fix', '--ignore-pattern=!.eslintrc.js']

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ all: test
 
 .PHONY: build
 build: node_modules
-	NODE_ENV=production ./node_modules/.bin/babel src --out-dir lib --copy-files
-	./node_modules/.bin/flow-copy-source src lib
+	NODE_ENV=production yarn babel src --out-dir lib --copy-files
+	yarn flow-copy-source src lib
 
 .PHONY: test
 test: venv node_modules
@@ -24,9 +24,8 @@ node_modules: package.json
 .PHONY: gen
 gen: node_modules
 	curl https://meyerweb.com/eric/tools/css/reset/reset.css | \
-		python gencss.py | \
-		node_modules/.bin/prettier --stdin --stdin-filepath=x.scss > \
-		src/components/LemonReset/LemonReset.scss
+		python patch_meyer_reset.py > \
+		src/components/LemonReset/LemonReset.css
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Wrap Lemon Reset components in your own custom components!
 
 ```javascript
 import { Span, Div } from 'lemon-reset';
-import styles from './Container.scss';
+import styles from './Container.css';
 
 type Props = {
     display: 'inline' | 'inline-block' | 'block' | 'none',
@@ -64,5 +64,5 @@ make build
 Otherwise, you can do:
 
 ```bash
-NODE_ENV=production ./node_modules/.bin/babel src --out-dir lib --copy-files
+NODE_ENV=production yarn babel src --out-dir lib --copy-files
 ```

--- a/patch_meyer_reset.py
+++ b/patch_meyer_reset.py
@@ -1,4 +1,4 @@
-"""Pass a reset css as stdin to be rewritten"""
+"""Add '.lemon--' prefixes to meyer reset styles."""
 import re
 import sys
 
@@ -10,14 +10,7 @@ def _replace(s, to_remove):
 
 def main():
     contents = sys.stdin.read()
-    # don't style body / html
-    contents = _replace(contents, 'html, body, ')
-    contents = _replace(contents, 'body {\n\tline-height: 1;\n}\n')
-    # meyer-reset has trailing whitespace :'(
-    contents = contents.replace(' \n', '\n')
-    # replace with our classname
     contents = re.sub('([a-z0-9:]+(,| {))', r'.lemon--\1', contents)
-
     sys.stdout.write(contents)
 
 

--- a/src/components/LemonReset/LemonReset.css
+++ b/src/components/LemonReset/LemonReset.css
@@ -3,6 +3,8 @@
    License: none (public domain)
 */
 
+.lemon--html,
+.lemon--body,
 .lemon--div,
 .lemon--span,
 .lemon--applet,
@@ -102,6 +104,9 @@
 .lemon--nav,
 .lemon--section {
     display: block;
+}
+.lemon--body {
+    line-height: 1;
 }
 .lemon--ol,
 .lemon--ul {

--- a/src/components/LemonReset/LemonReset.js
+++ b/src/components/LemonReset/LemonReset.js
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import styles from './LemonReset.scss';
+import styles from './LemonReset.css';
 
 type LemonResetType =
     | 'a'


### PR DESCRIPTION
Fixes #27.
- Move `src/components/LemonReset/LemonReset.scss` → `src/components/LemonReset/LemonReset.css` because there were no scss things in it.
- Change import paths in `src/components/LemonReset/LemonReset.js` and `README.md`
- Rename `gencss.py` → `patch_meyer_reset.py` and remove all things except for the addition of `.lemon--` prefixes because people will run `pre-commit` anyway? @mxmul is working on making it so that this file isn't even checked in and we only access it (via curl or npm) at prepublish time.
- Some boilerplate cleanup to use `yarn executable` instead of `./node_modules/bin/executable`