### PR TITLE
add a UMD distribution

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,10 @@ module.exports = {
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/prop-types.md
         'react/prop-types': 'off',
 
+        // we dynamically generate components at runtime, so these linters give false positives
+        'react/require-default-props': 'off',
+        'react/default-props-match-prop-types': 'off',
+
         // "type-annotations" isn't in the default options of 'react/sort-comp'.
         'react/sort-comp': [
             'error',

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 coverage/
 es/
 lib/
@@ -6,3 +7,4 @@ npm-debug.log
 venv/
 yarn.lock
 yarn-error.log
+*.css

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,24 @@
 all: test
 
 .PHONY: build
-build: node_modules
+build: es lib dist
+
+es: node_modules src src/components/LemonReset/LemonReset.css
 	NODE_ENV=production yarn babel src --out-dir es
-	NODE_ENV=production yarn babel src --plugins=transform-es2015-modules-commonjs --out-dir lib
-	yarn flow-copy-source src lib
+	cp src/components/LemonReset/LemonReset.css es/components/LemonReset/
 	yarn flow-copy-source src es
-	./patch-meyer-reset.js
+
+lib: node_modules src src/components/LemonReset/LemonReset.css
+	NODE_ENV=production yarn babel src --plugins=transform-es2015-modules-commonjs --out-dir lib
+	cp src/components/LemonReset/LemonReset.css lib/components/LemonReset/
+	yarn flow-copy-source src lib
+
+dist: node_modules src src/components/LemonReset/LemonReset.css webpack.config.js
+	NODE_ENV=production yarn webpack --mode=production
+	cp src/components/LemonReset/LemonReset.js dist/lemon-reset.js.flow
 
 .PHONY: test
-test: venv node_modules
+test: build venv node_modules
 	venv/bin/pre-commit install -f --install-hooks
 	venv/bin/pre-commit run --all-files
 	yarn typecheck
@@ -21,13 +30,12 @@ venv: Makefile requirements-dev.txt
 	virtualenv venv --python=python3.6
 	venv/bin/pip install -r requirements-dev.txt
 
+src/components/LemonReset/LemonReset.css: node_modules patch-meyer-reset.js
+	./patch-meyer-reset.js
+
 node_modules: package.json
 	yarn
 
 .PHONY: clean
 clean:
-	rm -rf coverage
-	rm -rf lib
-	rm -rf es
-	rm -rf node_modules
-	rm -rf venv
+	git clean -fdX

--- a/package.json
+++ b/package.json
@@ -11,15 +11,14 @@
     "prepublish": "make build",
     "typecheck": "flow check"
   },
-  "dependencies": {
-    "classnames": "^2.2.5"
-  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.1.2",
     "babel-jest": "^22.2.2",
+    "babel-loader": "^7",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-preset-react-app": "^3.0.1",
+    "css-loader": "^2.0.1",
     "empty": "^0.10.1",
     "enzyme": "^3.1.1",
     "enzyme-adapter-react-16": "^1.1.1",
@@ -35,16 +34,22 @@
     "flow-bin": "^0.74.0",
     "flow-copy-source": "^1.2.1",
     "identity-obj-proxy": "^3.0.0",
-    "jest": "^22.0.4",
+    "jest": "^23.6.0",
+    "mini-css-extract-plugin": "^0.5.0",
+    "optimize-css-assets-webpack-plugin": "^5.0.1",
     "prettier": "^1.10.2",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "reset-css": "^4.0.0"
+    "reset-css": "^4.0.0",
+    "uglifyjs-webpack-plugin": "^2.0.1",
+    "webpack": "^4.27.1",
+    "webpack-cli": "^3.1.2"
   },
   "peerDependencies": {
     "react": "15.x || 16.x"
   },
   "files": [
+    "dist",
     "es",
     "lib",
     "src"

--- a/patch-meyer-reset.js
+++ b/patch-meyer-reset.js
@@ -6,6 +6,4 @@ let contents = fs.readFileSync(require.resolve('reset-css'), { encoding: 'utf8' 
 // replace with our classname
 contents = contents.replace(/([a-z0-9:]+(,| {))/g, '.lemon--$1');
 
-['es', 'lib'].forEach(target => {
-    fs.writeFileSync(`${target}/components/LemonReset/LemonReset.css`, contents);
-});
+fs.writeFileSync('src/components/LemonReset/LemonReset.css', contents);

--- a/src/components/LemonReset/LemonReset.js
+++ b/src/components/LemonReset/LemonReset.js
@@ -1,8 +1,7 @@
 // @flow
 
 import * as React from 'react';
-import classNames from 'classnames';
-import styles from '../../../lib/components/LemonReset/LemonReset.css';
+import styles from './LemonReset.css';
 
 type LemonResetType =
     | 'a'
@@ -94,11 +93,19 @@ type Props = {
     tagRef?: ?React.Ref<*>,
 };
 
-export const LemonReset = ({ tag: Tag, children, className, tagRef, ...otherProps }: Props) => (
-    <Tag className={classNames(styles[`lemon--${Tag}`], className)} ref={tagRef} {...otherProps}>
-        {children}
-    </Tag>
-);
+export const LemonReset = ({ tag: Tag, children, className, tagRef, ...otherProps }: Props) => {
+    let classes = styles[`lemon--${Tag}`];
+    if (className != null && className !== '') {
+        classes += ` ${className}`;
+    }
+    return (
+        <Tag className={classes} ref={tagRef} {...otherProps}>
+            {children}
+        </Tag>
+    );
+};
+
+LemonReset.displayName = 'LemonReset';
 
 LemonReset.defaultProps = {
     children: null,
@@ -106,874 +113,109 @@ LemonReset.defaultProps = {
     tagRef: null,
 };
 
-type NoChildTagProps = {
-    className?: string,
-};
-
-export const Embed = ({ className, ...otherProps }: NoChildTagProps) => (
-    <LemonReset tag="embed" className={className} {...otherProps} />
-);
-
-Embed.defaultProps = {
-    className: '',
-};
-
-export const Img = ({ className, ...otherProps }: NoChildTagProps) => (
-    <LemonReset tag="img" className={className} {...otherProps} />
-);
-
-Img.defaultProps = {
-    className: '',
-};
-
 type TagProps = {
     children?: React.Node,
     className?: string,
 };
 
-export const A = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="a" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-A.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Abbr = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="abbr" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Abbr.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Acronym = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="acronym" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Acronym.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Address = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="address" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Address.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Applet = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="applet" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Applet.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Article = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="article" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Article.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Aside = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="aside" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Aside.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Audio = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="audio" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Audio.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const B = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="b" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-B.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Big = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="big" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Big.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Blockquote = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="blockquote" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Blockquote.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Canvas = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="canvas" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Canvas.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Caption = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="caption" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Caption.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Center = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="center" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Center.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Cite = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="cite" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Cite.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Code = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="code" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Code.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Dd = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="dd" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Dd.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Del = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="del" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Del.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Details = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="details" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Details.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Dfn = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="dfn" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Dfn.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Div = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="div" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Div.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Dl = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="dl" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Dl.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const DomObject = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="object" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-DomObject.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Dt = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="dt" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Dt.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Em = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="em" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Em.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Fieldset = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="fieldset" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Fieldset.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Figcaption = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="figcaption" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Figcaption.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Figure = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="figure" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Figure.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Footer = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="footer" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Footer.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Form = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="form" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Form.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const H1 = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="h1" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-H1.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const H2 = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="h2" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-H2.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const H3 = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="h3" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-H3.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const H4 = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="h4" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-H4.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const H5 = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="h5" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-H5.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const H6 = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="h6" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-H6.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Header = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="header" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Header.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Hgroup = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="hgroup" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Hgroup.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const I = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="i" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-I.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Iframe = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="iframe" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Iframe.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Ins = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="ins" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Ins.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Kbd = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="kbd" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Kbd.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Label = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="label" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Label.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Legend = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="legend" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Legend.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Li = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="li" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Li.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Mark = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="mark" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Mark.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Menu = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="menu" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Menu.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Nav = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="nav" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Nav.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Ol = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="ol" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Ol.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Output = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="output" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Output.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const P = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="p" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-P.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Pre = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="pre" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Pre.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Q = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="q" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Q.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Ruby = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="ruby" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Ruby.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const S = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="s" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-S.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Samp = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="samp" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Samp.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Section = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="section" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Section.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Small = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="small" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Small.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Span = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="span" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Span.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Strike = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="strike" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Strike.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Strong = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="strong" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Strong.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Sub = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="sub" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Sub.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Summary = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="summary" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Summary.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Sup = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="sup" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Sup.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Table = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="table" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Table.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Tbody = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="tbody" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Tbody.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Td = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="td" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Td.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Tfoot = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="tfoot" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Tfoot.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Th = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="th" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Th.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Thead = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="thead" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Thead.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Time = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="time" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Time.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Tr = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="tr" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Tr.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Tt = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="tt" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Tt.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const U = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="u" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-U.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Ul = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="ul" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Ul.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Var = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="var" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Var.defaultProps = {
-    children: null,
-    className: '',
-};
-
-export const Video = ({ children, className, ...otherProps }: TagProps) => (
-    <LemonReset tag="video" className={className} {...otherProps}>
-        {children}
-    </LemonReset>
-);
-
-Video.defaultProps = {
-    children: null,
-    className: '',
-};
+type NoChildTagProps = {
+    className?: string,
+};
+
+function createTagComponent(tag: LemonResetType) {
+    const component = (props: TagProps) => <LemonReset tag={tag} {...props} />;
+    component.defaultProps = {
+        className: '',
+    };
+    return component;
+}
+
+function createNoChildTagComponent(tag: LemonResetType) {
+    const component = (props: NoChildTagProps) => <LemonReset tag={tag} {...props} />;
+    component.defaultProps = {
+        children: null,
+        className: '',
+    };
+    return component;
+}
+
+export const Embed = createNoChildTagComponent('embed');
+export const Img = createNoChildTagComponent('img');
+
+export const A = createTagComponent('a');
+export const Abbr = createTagComponent('abbr');
+export const Acronym = createTagComponent('acronym');
+export const Address = createTagComponent('address');
+export const Applet = createTagComponent('applet');
+export const Article = createTagComponent('article');
+export const Aside = createTagComponent('aside');
+export const Audio = createTagComponent('audio');
+export const B = createTagComponent('b');
+export const Big = createTagComponent('big');
+export const Blockquote = createTagComponent('blockquote');
+export const Canvas = createTagComponent('canvas');
+export const Caption = createTagComponent('caption');
+export const Center = createTagComponent('center');
+export const Cite = createTagComponent('cite');
+export const Code = createTagComponent('code');
+export const Dd = createTagComponent('dd');
+export const Del = createTagComponent('del');
+export const Details = createTagComponent('details');
+export const Dfn = createTagComponent('dfn');
+export const Div = createTagComponent('div');
+export const Dl = createTagComponent('dl');
+export const DomObject = createTagComponent('object');
+export const Dt = createTagComponent('dt');
+export const Em = createTagComponent('em');
+export const Fieldset = createTagComponent('fieldset');
+export const Figcaption = createTagComponent('figcaption');
+export const Figure = createTagComponent('figure');
+export const Footer = createTagComponent('footer');
+export const Form = createTagComponent('form');
+export const H1 = createTagComponent('h1');
+export const H2 = createTagComponent('h2');
+export const H3 = createTagComponent('h3');
+export const H4 = createTagComponent('h4');
+export const H5 = createTagComponent('h5');
+export const H6 = createTagComponent('h6');
+export const Header = createTagComponent('header');
+export const Hgroup = createTagComponent('hgroup');
+export const I = createTagComponent('i');
+export const Iframe = createTagComponent('iframe');
+export const Ins = createTagComponent('ins');
+export const Kbd = createTagComponent('kbd');
+export const Label = createTagComponent('label');
+export const Legend = createTagComponent('legend');
+export const Li = createTagComponent('li');
+export const Mark = createTagComponent('mark');
+export const Menu = createTagComponent('menu');
+export const Nav = createTagComponent('nav');
+export const Ol = createTagComponent('ol');
+export const Output = createTagComponent('output');
+export const P = createTagComponent('p');
+export const Pre = createTagComponent('pre');
+export const Q = createTagComponent('q');
+export const Ruby = createTagComponent('ruby');
+export const S = createTagComponent('s');
+export const Samp = createTagComponent('samp');
+export const Section = createTagComponent('section');
+export const Small = createTagComponent('small');
+export const Span = createTagComponent('span');
+export const Strike = createTagComponent('strike');
+export const Strong = createTagComponent('strong');
+export const Sub = createTagComponent('sub');
+export const Summary = createTagComponent('summary');
+export const Sup = createTagComponent('sup');
+export const Table = createTagComponent('table');
+export const Tbody = createTagComponent('tbody');
+export const Td = createTagComponent('td');
+export const Tfoot = createTagComponent('tfoot');
+export const Th = createTagComponent('th');
+export const Thead = createTagComponent('thead');
+export const Time = createTagComponent('time');
+export const Tr = createTagComponent('tr');
+export const Tt = createTagComponent('tt');
+export const U = createTagComponent('u');
+export const Ul = createTagComponent('ul');
+export const Var = createTagComponent('var');
+export const Video = createTagComponent('video');

--- a/tests/components/LemonReset/LemonReset.test.js
+++ b/tests/components/LemonReset/LemonReset.test.js
@@ -1,136 +1,148 @@
 import React from 'react';
 import { render, shallow } from 'enzyme';
-import * as Lemon from '../../../src';
+import * as LemonSrc from '../../../src';
+import * as LemonES from '../../../es';
+import * as LemonCommonJS from '../../../lib';
+import * as LemonUMD from '../../../dist/lemon-reset';
 
-describe('Lemon', () => {
-    it('renders the tag with correct styles', () => {
-        const wrapper = render(<Lemon.Div className="test">ohai</Lemon.Div>);
-        expect(wrapper.hasClass('lemon--div')).toBe(true);
-        expect(wrapper.hasClass('test')).toBe(true);
-    });
+function hasClass(wrapper, pattern) {
+    const classes = wrapper.attr('class').split(/\s+/);
+    const matching = classes.filter(cls => pattern.test(cls));
+    return matching.length > 0;
+}
 
-    it('renders all tags with correct styles', () => {
-        const allTags = [
-            ['a', Lemon.A],
-            ['abbr', Lemon.Abbr],
-            ['acronym', Lemon.Acronym],
-            ['address', Lemon.Address],
-            ['applet', Lemon.Applet],
-            ['article', Lemon.Article],
-            ['aside', Lemon.Aside],
-            ['audio', Lemon.Audio],
-            ['b', Lemon.B],
-            ['big', Lemon.Big],
-            ['blockquote', Lemon.Blockquote],
-            ['canvas', Lemon.Canvas],
-            ['caption', Lemon.Caption],
-            ['center', Lemon.Center],
-            ['cite', Lemon.Cite],
-            ['code', Lemon.Code],
-            ['dd', Lemon.Dd],
-            ['del', Lemon.Del],
-            ['details', Lemon.Details],
-            ['dfn', Lemon.Dfn],
-            ['div', Lemon.Div],
-            ['dl', Lemon.Dl],
-            ['dt', Lemon.Dt],
-            ['em', Lemon.Em],
-            ['fieldset', Lemon.Fieldset],
-            ['figcaption', Lemon.Figcaption],
-            ['figure', Lemon.Figure],
-            ['footer', Lemon.Footer],
-            ['form', Lemon.Form],
-            ['h1', Lemon.H1],
-            ['h2', Lemon.H2],
-            ['h3', Lemon.H3],
-            ['h4', Lemon.H4],
-            ['h5', Lemon.H5],
-            ['h6', Lemon.H6],
-            ['header', Lemon.Header],
-            ['hgroup', Lemon.Hgroup],
-            ['i', Lemon.I],
-            ['iframe', Lemon.Iframe],
-            ['ins', Lemon.Ins],
-            ['kbd', Lemon.Kbd],
-            ['label', Lemon.Label],
-            ['legend', Lemon.Legend],
-            ['li', Lemon.Li],
-            ['mark', Lemon.Mark],
-            ['menu', Lemon.Menu],
-            ['nav', Lemon.Nav],
-            ['object', Lemon.DomObject],
-            ['ol', Lemon.Ol],
-            ['output', Lemon.Output],
-            ['p', Lemon.P],
-            ['pre', Lemon.Pre],
-            ['q', Lemon.Q],
-            ['ruby', Lemon.Ruby],
-            ['s', Lemon.S],
-            ['samp', Lemon.Samp],
-            ['section', Lemon.Section],
-            ['small', Lemon.Small],
-            ['span', Lemon.Span],
-            ['strike', Lemon.Strike],
-            ['strong', Lemon.Strong],
-            ['sub', Lemon.Sub],
-            ['summary', Lemon.Summary],
-            ['sup', Lemon.Sup],
-            ['td', Lemon.Td],
-            ['th', Lemon.Th],
-            ['time', Lemon.Time],
-            ['tt', Lemon.Tt],
-            ['u', Lemon.U],
-            ['ul', Lemon.Ul],
-            ['var', Lemon.Var],
-            ['video', Lemon.Video],
-        ];
-
-        allTags.forEach(([tag, Component]) => {
-            const wrapper = render(<Component className="test">ohai</Component>);
-            expect(wrapper.hasClass(`lemon--${tag}`)).toBe(true);
-            expect(wrapper.hasClass('test')).toBe(true);
+describe.each([['umd', LemonUMD], ['commonjs', LemonCommonJS], ['es', LemonES], ['src', LemonSrc]])(
+    'lemon-reset %s',
+    (distribution, Lemon) => {
+        it('renders the tag with correct styles', () => {
+            const wrapper = render(<Lemon.Div className="test">ohai</Lemon.Div>);
+            expect(hasClass(wrapper, /^lemon--div/)).toBe(true);
+            expect(hasClass(wrapper, /^test$/)).toBe(true);
         });
-    });
 
-    it('renders elements without children', () => {
-        let wrapper = render(<Lemon.Embed src="/example" />);
-        expect(wrapper.hasClass('lemon--embed')).toBe(true);
-        wrapper = render(<Lemon.Img src="/example" />);
-        expect(wrapper.hasClass('lemon--img')).toBe(true);
-        wrapper = render(<Lemon.Iframe src="/example" />);
-        expect(wrapper.hasClass('lemon--iframe')).toBe(true);
-    });
+        it('renders all tags with correct styles', () => {
+            const allTags = [
+                ['a', Lemon.A],
+                ['abbr', Lemon.Abbr],
+                ['acronym', Lemon.Acronym],
+                ['address', Lemon.Address],
+                ['applet', Lemon.Applet],
+                ['article', Lemon.Article],
+                ['aside', Lemon.Aside],
+                ['audio', Lemon.Audio],
+                ['b', Lemon.B],
+                ['big', Lemon.Big],
+                ['blockquote', Lemon.Blockquote],
+                ['canvas', Lemon.Canvas],
+                ['caption', Lemon.Caption],
+                ['center', Lemon.Center],
+                ['cite', Lemon.Cite],
+                ['code', Lemon.Code],
+                ['dd', Lemon.Dd],
+                ['del', Lemon.Del],
+                ['details', Lemon.Details],
+                ['dfn', Lemon.Dfn],
+                ['div', Lemon.Div],
+                ['dl', Lemon.Dl],
+                ['dt', Lemon.Dt],
+                ['em', Lemon.Em],
+                ['fieldset', Lemon.Fieldset],
+                ['figcaption', Lemon.Figcaption],
+                ['figure', Lemon.Figure],
+                ['footer', Lemon.Footer],
+                ['form', Lemon.Form],
+                ['h1', Lemon.H1],
+                ['h2', Lemon.H2],
+                ['h3', Lemon.H3],
+                ['h4', Lemon.H4],
+                ['h5', Lemon.H5],
+                ['h6', Lemon.H6],
+                ['header', Lemon.Header],
+                ['hgroup', Lemon.Hgroup],
+                ['i', Lemon.I],
+                ['iframe', Lemon.Iframe],
+                ['ins', Lemon.Ins],
+                ['kbd', Lemon.Kbd],
+                ['label', Lemon.Label],
+                ['legend', Lemon.Legend],
+                ['li', Lemon.Li],
+                ['mark', Lemon.Mark],
+                ['menu', Lemon.Menu],
+                ['nav', Lemon.Nav],
+                ['object', Lemon.DomObject],
+                ['ol', Lemon.Ol],
+                ['output', Lemon.Output],
+                ['p', Lemon.P],
+                ['pre', Lemon.Pre],
+                ['q', Lemon.Q],
+                ['ruby', Lemon.Ruby],
+                ['s', Lemon.S],
+                ['samp', Lemon.Samp],
+                ['section', Lemon.Section],
+                ['small', Lemon.Small],
+                ['span', Lemon.Span],
+                ['strike', Lemon.Strike],
+                ['strong', Lemon.Strong],
+                ['sub', Lemon.Sub],
+                ['summary', Lemon.Summary],
+                ['sup', Lemon.Sup],
+                ['td', Lemon.Td],
+                ['th', Lemon.Th],
+                ['time', Lemon.Time],
+                ['tt', Lemon.Tt],
+                ['u', Lemon.U],
+                ['ul', Lemon.Ul],
+                ['var', Lemon.Var],
+                ['video', Lemon.Video],
+            ];
 
-    it('renders a table properly', () => {
-        const wrapper = render(
-            <Lemon.Table>
-                <Lemon.Thead>
-                    <Lemon.Tr>
-                        <Lemon.Th>wow</Lemon.Th>
-                    </Lemon.Tr>
-                </Lemon.Thead>
-                <Lemon.Tbody>
-                    <Lemon.Tr>
-                        <Lemon.Td>wow</Lemon.Td>
-                    </Lemon.Tr>
-                </Lemon.Tbody>
-                <Lemon.Tfoot>
-                    <Lemon.Tr>
-                        <Lemon.Td>wow</Lemon.Td>
-                    </Lemon.Tr>
-                </Lemon.Tfoot>
-            </Lemon.Table>,
-        );
-        expect(wrapper.hasClass('lemon--table')).toBe(true);
-    });
+            allTags.forEach(([tag, Component]) => {
+                const wrapper = render(<Component className="test">ohai</Component>);
+                expect(hasClass(wrapper, new RegExp(`^lemon--${tag}`))).toBe(true);
+                expect(hasClass(wrapper, /^test$/)).toBe(true);
+            });
+        });
 
-    it('renders the tag with additional props', () => {
-        const wrapper = render(<Lemon.A href="/example">ohai</Lemon.A>);
-        expect(wrapper.hasClass('lemon--a')).toBe(true);
-    });
+        it('renders elements without children', () => {
+            let wrapper = render(<Lemon.Embed src="/example" />);
+            expect(hasClass(wrapper, /^lemon--embed/)).toBe(true);
+            wrapper = render(<Lemon.Img src="/example" />);
+            expect(hasClass(wrapper, /^lemon--img/)).toBe(true);
+            wrapper = render(<Lemon.Iframe src="/example" />);
+            expect(hasClass(wrapper, /^lemon--iframe/)).toBe(true);
+        });
 
-    it('passes a snapshot test', () => {
-        const wrapper = shallow(<Lemon.Div>ohai</Lemon.Div>);
-        expect(wrapper).toMatchSnapshot();
-    });
-});
+        it('renders a table properly', () => {
+            const wrapper = render(
+                <Lemon.Table>
+                    <Lemon.Thead>
+                        <Lemon.Tr>
+                            <Lemon.Th>wow</Lemon.Th>
+                        </Lemon.Tr>
+                    </Lemon.Thead>
+                    <Lemon.Tbody>
+                        <Lemon.Tr>
+                            <Lemon.Td>wow</Lemon.Td>
+                        </Lemon.Tr>
+                    </Lemon.Tbody>
+                    <Lemon.Tfoot>
+                        <Lemon.Tr>
+                            <Lemon.Td>wow</Lemon.Td>
+                        </Lemon.Tr>
+                    </Lemon.Tfoot>
+                </Lemon.Table>,
+            );
+            expect(hasClass(wrapper, /^lemon--table/)).toBe(true);
+        });
+
+        it('renders the tag with additional props', () => {
+            const wrapper = render(<Lemon.A href="/example">ohai</Lemon.A>);
+            expect(hasClass(wrapper, /^lemon--a/)).toBe(true);
+        });
+
+        it('passes a snapshot test', () => {
+            const wrapper = shallow(<Lemon.Div>ohai</Lemon.Div>);
+            expect(wrapper).toMatchSnapshot();
+        });
+    },
+);

--- a/tests/components/LemonReset/__snapshots__/LemonReset.test.js.snap
+++ b/tests/components/LemonReset/__snapshots__/LemonReset.test.js.snap
@@ -1,6 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Lemon passes a snapshot test 1`] = `
+exports[`lemon-reset commonjs passes a snapshot test 1`] = `
+<LemonReset
+  className=""
+  tag="div"
+  tagRef={null}
+>
+  ohai
+</LemonReset>
+`;
+
+exports[`lemon-reset es passes a snapshot test 1`] = `
+<LemonReset
+  className=""
+  tag="div"
+  tagRef={null}
+>
+  ohai
+</LemonReset>
+`;
+
+exports[`lemon-reset src passes a snapshot test 1`] = `
+<LemonReset
+  className=""
+  tag="div"
+  tagRef={null}
+>
+  ohai
+</LemonReset>
+`;
+
+exports[`lemon-reset umd passes a snapshot test 1`] = `
 <LemonReset
   className=""
   tag="div"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,68 @@
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+
+module.exports = {
+    entry: {
+        'lemon-reset': './src/index.js',
+    },
+    output: {
+        library: 'LemonReset',
+        libraryTarget: 'umd',
+    },
+    externals: {
+        react: {
+            commonjs: 'react',
+            commonjs2: 'react',
+            amd: 'React',
+            root: 'React',
+        },
+    },
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        babelrc: true,
+                    },
+                },
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    MiniCssExtractPlugin.loader,
+                    {
+                        loader: 'css-loader',
+                        options: {
+                            modules: true,
+                            localIdentName: '[local]--[hash:base64:5]',
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+    optimization: {
+        minimizer: [
+            new UglifyJsPlugin({
+                cache: true,
+                parallel: true,
+                sourceMap: true,
+                uglifyOptions: {
+                    output: {
+                        comments: false,
+                    },
+                },
+            }),
+            new OptimizeCSSAssetsPlugin({}),
+        ],
+    },
+    plugins: [
+        new MiniCssExtractPlugin({
+            filename: '[name].css',
+        }),
+    ],
+};


### PR DESCRIPTION
Current ES / CommonJS distributions of lemon-reset make some assumptions about your build process (namely that you have css-loader, extract-text, etc... set up). This provides a pair of JS / CSS bundles that can be used independently in any module system, or directly in a browser without a build step. E.g:

```html
<!DOCTYPE html>
<head>
    <link rel="stylesheet" href="./dist/lemon-reset.css" />
    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
    <script src="./dist/lemon-reset.js"></script>
</head>
<body>
    <div id="app" />
    <script>
        ReactDOM.render(
            React.createElement(
                LemonReset.H1,
                null,
                ['hello!'],
            ),
            document.getElementById('app')
        );
    </script>
</body>
```

I also refactored a bunch of stuff to make the build smaller while I was here (the JS bundle is now 8K / 2K gzipped, down from 22K).

Having the standalone CSS bundle is especially helpful when you want to include lemon-reset in multiple JS bundles on a page without worrying about the reset styles in the second bundle overriding custom styles from the first bundle.