### PR TITLE
Remove greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![npm](https://img.shields.io/npm/v/lemon-reset.svg)](https://yarn.pm/lemon-reset)
 [![Build Status](https://travis-ci.org/Yelp/lemon-reset.svg?branch=master)](https://travis-ci.org/Yelp/lemon-reset)
-[![Greenkeeper badge](https://badges.greenkeeper.io/Yelp/lemon-reset.svg)](https://greenkeeper.io/)
 [![gzip size](http://img.badgesize.io/https://unpkg.com/lemon-reset/dist/lemon-reset.js?compression=gzip)](https://unpkg.com/lemon-reset/dist/lemon-reset.js)
 [![install size](https://packagephobia.now.sh/badge?p=lemon-reset)](https://packagephobia.now.sh/result?p=lemon-reset)
 


### PR DESCRIPTION
We turned off greenkeeper so the badge is 404ing now - removing it.