### PR TITLE
[WIP] Improve rendering performance of LemonReset elelments

### DIFF
--- a/src/components/LemonReset/LemonReset.js
+++ b/src/components/LemonReset/LemonReset.js
@@ -128,6 +128,30 @@ type NoChildTagProps = {
     className?: string,
 };
 
+export function exp_createTagComponent(Tag: LemonResetType, displayName: string) {
+    const component = <T: string & LemonResetType>({
+        children,
+        className,
+        tagRef,
+        ...otherProps
+    }: Props<T>) => {
+        let classes = styles[`lemon--${Tag}`];
+        if (className != null && className !== '') {
+            classes += ` ${className}`;
+        }
+        return (
+            <Tag className={classes} ref={tagRef} {...otherProps}>
+                {children}
+            </Tag>
+        );
+    };
+    component.defaultProps = {
+        className: '',
+    };
+    component.displayName = displayName;
+    return component;
+}
+
 function createTagComponent(tag: LemonResetType, displayName: string) {
     const component = (props: TagProps) => <LemonReset tag={tag} {...props} />;
     component.defaultProps = {
@@ -227,3 +251,5 @@ export const U = createTagComponent('u', 'U');
 export const Ul = createTagComponent('ul', 'Ul');
 export const Var = createTagComponent('var', 'Var');
 export const Video = createTagComponent('video', 'Video');
+
+export const FastDiv = exp_createTagComponent('div', 'Div');

--- a/tests/components/LemonReset/perf.test.js
+++ b/tests/components/LemonReset/perf.test.js
@@ -23,8 +23,14 @@ function doTest(Component, reps) {
 
 describe('speed', () => {
     it('goes fast', () => {
-        const oldSpeed = doTest(Div, 10);
+        // warmup
+        doTest(FastDiv, 10);
+        doTest(Div, 10);
+
+        // actually do the tests for realsies
         const newSpeed = doTest(FastDiv, 10);
+        const oldSpeed = doTest(Div, 10);
+
         console.log(`<Div />: ${oldSpeed}\n<FastDiv />: ${newSpeed}`);
     });
 });

--- a/tests/components/LemonReset/perf.test.js
+++ b/tests/components/LemonReset/perf.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+
+import { Div, FastDiv } from '../../../src';
+
+function doTest(Component, reps) {
+    const startTime = performance.now();
+
+    for (let i = 0; i < reps; i++) {
+        ReactDOMServer.renderToString(
+            <>
+                {new Array(1000).fill().map(i => (
+                    <Component key={i} />
+                ))}
+            </>,
+        );
+    }
+
+    const endTime = performance.now();
+
+    return endTime - startTime;
+}
+
+describe('speed', () => {
+    it('goes fast', () => {
+        const oldSpeed = doTest(Div, 10);
+        const newSpeed = doTest(FastDiv, 10);
+        console.log(`<Div />: ${oldSpeed}\n<FastDiv />: ${newSpeed}`);
+    });
+});


### PR DESCRIPTION
Currently, all exported LemonReset components render two nodes to the virtual DOM: the one requested by the developer (`Div`, `Span`, etc), and the `LemonReset` that actually has all the logic of adding classnames and rendering the native browser tag.

Rendering a node to the VDOM has some amount of overhead to it; this PR aims to reduce this by having the developer-exposed components directly contain all the logic of the `LemonReset` component rather than incur the overhead of rendering a second node. This appears to improve rendering performance by around 25%, at least in my super basic test that renders 1000 empty components to a string ten times:

```
$ yarn test perf

<Div />: 190.29534599999988
<FastDiv />: 140.82859099999996
```

It's harder to benchmark interactivity, but it's likely that having a VDOM with half as many nodes will improve reconciliation times as well.

This will increase bundle sizes slightly, since we're basically duplicating the `LemonReset` component, but a few dozen bytes gzipped is worth the perfomance boost IMO.

I'll finish the implementation and write tests if this gets an initial green light.