### PR TITLE
set up "trusted publishers" for releasing to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     release:
         types: [created]
 
+permissions:
+    id-token: write  # required for publishing
+
 jobs:
     test:
         runs-on: ubuntu-20.04
@@ -27,7 +30,6 @@ jobs:
               with:
                   node-version: '16.x'
                   registry-url: https://registry.npmjs.org/
+            - run: npm install -g yarn@latest
             - run: yarn
             - run: yarn publish
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
     release:
         types: [created]
 
-permissions:
-    id-token: write  # required for publishing
-
 jobs:
     test:
         runs-on: ubuntu-20.04
@@ -24,6 +21,8 @@ jobs:
     publish-npm:
         needs: test
         runs-on: ubuntu-20.04
+        permissions:
+            id-token: write  # required for publishing
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4


### PR DESCRIPTION
I've set things up in the npmjs settings for this package, and YARN should have support for the OIDC workflow in https://github.com/yarnpkg/berry/pull/6898.

How can we reasonably test this? I absolutely have no idea other than trying to release a new version of the package after shipping this change.

I strongly suspect that this repo is going to hit some issues for using a NodeJS version which is a bit too old.